### PR TITLE
fix typo in create_heatmaps.py

### DIFF
--- a/create_heatmaps.py
+++ b/create_heatmaps.py
@@ -33,7 +33,7 @@ args = parser.parse_args()
 def infer_single_slide(model, features, label, reverse_label_dict, k=1):
 	features = features.to(device)
 	with torch.no_grad():
-		if isinstance(model, (CLAM_SB, CLAM_BM)):
+		if isinstance(model, (CLAM_SB, CLAM_MB)):
 			model_results_dict = model(features)
 			logits, Y_prob, Y_hat, A, _ = model(features)
 			Y_hat = Y_hat.item()


### PR DESCRIPTION
This should fix the below error I get when running create_heatmaps:

Traceback (most recent call last):
  File "create_heatmaps.py", line 308, in <module>
    Y_hats, Y_hats_str, Y_probs, A = infer_single_slide(model, features, label, reverse_label_dict, exp_args.n_classes)
  File "create_heatmaps.py", line 36, in infer_single_slide
    if isinstance(model, (CLAM_SB, CLAM_BM)):
NameError: name 'CLAM_BM' is not defined