### PR TITLE
Update WholeSlideImage.py

### DIFF
--- a/wsi_core/WholeSlideImage.py
+++ b/wsi_core/WholeSlideImage.py
@@ -460,7 +460,7 @@ class WholeSlideImage(object):
         
         print('Extracted {} coordinates'.format(len(results)))
 
-        if len(results)>1:
+        if len(results)>0:
             asset_dict = {'coords' :          results}
             
             attr = {'patch_size' :            patch_size, # To be considered...


### PR DESCRIPTION
Reduce minimum number of patches per slide from 2 to 1. This is particularly useful when using large patches, such as the 4096x4096 patches of HIPT_4K.