### PR TITLE
Add setting the objective magnification when patching

### DIFF
--- a/dataset_modules/dataset_h5.py
+++ b/dataset_modules/dataset_h5.py
@@ -64,6 +64,8 @@ class Whole_Slide_Bag_FP(Dataset):
 			dset = f['coords']
 			self.patch_level = f['coords'].attrs['patch_level']
 			self.patch_size = f['coords'].attrs['patch_size']
+			self.target_patch_size = f['coords'].attrs['target_patch_size']
+			self.custom_downsample = f['coords'].attrs['custom_downsample']
 			self.length = len(dset)
 			
 		self.summary()
@@ -84,7 +86,8 @@ class Whole_Slide_Bag_FP(Dataset):
 		with h5py.File(self.file_path,'r') as hdf5_file:
 			coord = hdf5_file['coords'][idx]
 		img = self.wsi.read_region(coord, self.patch_level, (self.patch_size, self.patch_size)).convert('RGB')
-
+		if self.custom_downsample > 1:
+			img = img.resize((self.target_patch_size, self.target_patch_size))
 		img = self.roi_transforms(img)
 		return {'img': img, 'coord': coord}
 


### PR DESCRIPTION
The current code only supports patching at a specified 'patch_level' of the WSI. However, in actual research, the objective magnification is usually specified for patching. 

Therefore, I added functionality to the fast patching pipeline to allow specifying the objective magnification during patching. The objective magnification attribute is set to 'None' by default. When the objective magnification is specified, the 'patch_level' will be ignored, and the code will automatically select an appropriate 'patch_level' and corresponding 'custom_downsample' based on the WSI. Additionally, I made corresponding modifications to 'dataset_h5.py' to enable custom downsampling during feature extraction.