### PR TITLE
Fix: Resolve negative seg_level before passing to OpenSlide

### DIFF
--- a/wsi_core/WholeSlideImage.py
+++ b/wsi_core/WholeSlideImage.py
@@ -93,7 +93,12 @@ class WholeSlideImage(object):
         """
             Segment the tissue via HSV -> Median thresholding -> Binary threshold
         """
-        
+
+        # Resolve negative seg_level before passing to OpenSlide
+        # OpenSlide's C library doesn't support Python's negative indexing
+        if seg_level<0:
+            seg_level = self.wsi.get_best_level_for_downsample(64)
+
         def _filter_contours(contours, hierarchy, filter_params):
             """
                 Filter contours by: area.


### PR DESCRIPTION
## Problem
OpenSlide's C library doesn't support Python's negative indexing. When `seg_level=-1` is passed, `read_region` returns a black image, causing `findContours` to return zero contours and `hierarchy=None`, which crashes at `np.squeeze()`.

## Fix
This fix converts negative `seg_level` to the appropriate positive level using `get_best_level_for_downsample(64)` before any OpenSlide calls.