### PR TITLE
Fix conda deactivate command in installation docs

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -17,7 +17,7 @@ pip install git+https://github.com/Mahmoodlab/CONCH.git
 
 When done running experiments, to deactivate the environment:
 ```shell
-conda deactivate clam_latest
+conda deactivate
 ```
 Please report any issues in the public forum.
 


### PR DESCRIPTION
Fixes #311.

This updates the installation guide to use the standard conda deactivation command:

```shell
conda deactivate
```

The previous command included the environment name, which is not valid for `conda deactivate`.